### PR TITLE
Replace reboot with sudo su to load new user group config without headaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ sudo usermod -aG kvm $USER
 sudo usermod -aG wireshark $USER
 sudo usermod -aG docker $USER
 # loading new user group config
-sudo reboot
+sudo su $USER
 ```
 
 ### Get docker images


### PR DESCRIPTION
This works too, and doesn't require reboot.

Signed-off-by: Mohammad Ali Toufighi <alitoumob@gmail.com>